### PR TITLE
TESuit build fault: Declared header name != Real file name

### DIFF
--- a/src/LLL/AVR/Common/Macro/FuncImplSet_mac.h
+++ b/src/LLL/AVR/Common/Macro/FuncImplSet_mac.h
@@ -19,7 +19,7 @@
 #ifndef _FuncImplSet_mac_h_
 #define _FuncImplSet_mac_h_
 
-#include "BasicFunc_mac.h"
+#include "BasicFunc_Mac.h"
 
 #define IMPL_GET_FUNC(__ReturnType, __FuncName, __ReturnValue) \
   IMPL_FUNC(, __ReturnType, Get_##__FuncName, , return __ReturnValue;)


### PR DESCRIPTION
Real file name is "BasicFunc_Mac.h"
but declared header name in FuncImplSet_mac.h is "BasicFunc_mac.h".